### PR TITLE
enable customized default location

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,19 @@ aivoc remove enormous depicted
 示例：
 
 ```
-export OPENAI_API_KEY='your_api_key' 
+export OPENAI_API_KEY='your_api_key'
 ```
+
+### AIVOC_DATA_DIR
+
+指定生词本储存数据文件的路径, 默认路径为当前登录用户的 home 目录: `~/`
+
+示例：
+
+```
+export AIVOC_DATA_DIR="$HOME/Documents"
+```
+
 
 ## 为什么开发这个工具？
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,8 +1,13 @@
+import importlib
+import os
 import time
 from dataclasses import asdict
+from pathlib import Path
 
+import pytest
 from tinydb import Query
 
+from voc_builder import config
 from voc_builder.models import WordProgress, WordSample
 from voc_builder.store import InternalStateStore, MasteredWordStore, WordStore
 
@@ -118,3 +123,20 @@ class TestInternalStateStore:
         state_store.set_last_ver_checking_ts()
         new_ts = state_store.get_last_ver_checking_ts()
         assert new_ts and new_ts > ts
+
+
+class TestStoreDir:
+    def test_mocked_location(self, tmp_path):
+        assert config.DEFAULT_DB_PATH == tmp_path
+        assert config.DEFAULT_CSV_FILE_PATH == tmp_path / 'foo.csv'
+
+    def test_data_dir_location(self, monkeypatch, tmp_path):
+        # Set the environment variable to a test value
+        monkeypatch.setenv('AIVOC_DATA_DIR', str(tmp_path))
+
+        # Reload the module to pick up the new environment variable value
+        importlib.reload(config)
+
+        data_dir = Path(os.environ['AIVOC_DATA_DIR']).expanduser()
+        assert config.DEFAULT_DB_PATH == data_dir / '.aivoc_db'
+        assert config.DEFAULT_CSV_FILE_PATH == data_dir / 'aivoc_builder.csv'

--- a/voc_builder/config.py
+++ b/voc_builder/config.py
@@ -1,9 +1,11 @@
 """Store configuration for project"""
+import os
 from pathlib import Path
 
 # Testings should patch these variables
 #
 # The default path for storing the vocabulary book
-DEFAULT_CSV_FILE_PATH = Path('~/aivoc_builder.csv').expanduser()
+aivoc_home = os.environ.get("AIVOC_HOME", "~")
+DEFAULT_CSV_FILE_PATH = Path(f"{aivoc_home}/aivoc_builder.csv").expanduser()
 # The default path for storing db files
-DEFAULT_DB_PATH = Path('~/.aivoc_db').expanduser()
+DEFAULT_DB_PATH = Path(f"{aivoc_home}/.aivoc_db").expanduser()

--- a/voc_builder/config.py
+++ b/voc_builder/config.py
@@ -5,7 +5,10 @@ from pathlib import Path
 # Testings should patch these variables
 #
 # The default path for storing the vocabulary book
-aivoc_home = os.environ.get("AIVOC_HOME", "~")
-DEFAULT_CSV_FILE_PATH = Path(f"{aivoc_home}/aivoc_builder.csv").expanduser()
+data_dir = os.environ.get('AIVOC_DATA_DIR', '~')
+if data_dir.endswith('/'):
+    data_dir = data_dir[:-1]
+
+DEFAULT_CSV_FILE_PATH = Path(f'{data_dir}/aivoc_builder.csv').expanduser()
 # The default path for storing db files
-DEFAULT_DB_PATH = Path(f"{aivoc_home}/.aivoc_db").expanduser()
+DEFAULT_DB_PATH = Path(f'{data_dir}/.aivoc_db').expanduser()

--- a/voc_builder/config.py
+++ b/voc_builder/config.py
@@ -5,10 +5,7 @@ from pathlib import Path
 # Testings should patch these variables
 #
 # The default path for storing the vocabulary book
-data_dir = os.environ.get('AIVOC_DATA_DIR', '~')
-if data_dir.endswith('/'):
-    data_dir = data_dir[:-1]
-
-DEFAULT_CSV_FILE_PATH = Path(f'{data_dir}/aivoc_builder.csv').expanduser()
+data_dir = Path(os.environ.get('AIVOC_DATA_DIR', '~')).expanduser()
+DEFAULT_CSV_FILE_PATH = data_dir / 'aivoc_builder.csv'
 # The default path for storing db files
-DEFAULT_DB_PATH = Path(f'{data_dir}/.aivoc_db').expanduser()
+DEFAULT_DB_PATH = data_dir / '.aivoc_db'


### PR DESCRIPTION
Feature: Enable customization of default store files location using `AIVOC_HOME` environment variable
-----------------------------------------------------------------------------------------------------

### Motivation

I use [a-shell](https://github.com/holzschu/a-shell) to run Aivoc on my iPhone. However, due to file permission limitations, the `~/.aivoc_db` directory is expanded to `/private/var/mobile/Containers/Data/Application/xxxx/.aivoc_db`, which a-shell does not have permission to write in.

### Solution

To overcome this limitation, I propose providing a way to customize the default location of store files by introducing the `AIVOC_HOME` environment variable. This feature will allow users to set the `AIVOC_HOME` variable to a directory where Aivoc can write store files.

For example:


```bash
export AIVOC_HOME=$HOME/Documents
aivoc
```

This solution will be particularly useful for iOS users who cannot write in the `~` directory and can only write in `~/Documents/`, `~/Library/` and `~/tmp` directories.

As per a-shell documentation:


> In iOS, you cannot write in the ~ directory, only in ~/Documents/, ~/Library/ and ~/tmp. Most Unix programs assume the configuration files are in $HOME.



_pull request message written by ChatGPT_