### PR TITLE
fix docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM python:3.10-slim AS builder
 RUN pip install poetry
 WORKDIR /app
 COPY pyproject.toml poetry.lock ./
-RUN poetry config virtualenvs.create false && poetry install --no-interaction --no-ansi
+RUN poetry config virtualenvs.create false && poetry install --no-root --no-interaction --no-ansi
 COPY --from=frontend-builder /app/voc_frontend/dist ./voc_builder/notepad/dist
 COPY voc_builder ./voc_builder
 # ========================== Stage 3: Final Runtime Image ========================= #


### PR DESCRIPTION
When I tried to build the project, I ran into the following error. We can use `--no-root` to skip the installation. 

FYI: https://python-poetry.org/docs/cli/#options-8

```
29.10 
29.10 Installing the current project: ai-vocabulary-builder (1.4.1)
29.11 
29.11 /app/voc_builder does not contain any element
------
Dockerfile:13
--------------------
  11 |     WORKDIR /app
  12 |     COPY pyproject.toml poetry.lock README.md ./
  13 | >>> RUN poetry config virtualenvs.create false && poetry install --no-interaction --no-ansi
  14 |     COPY --from=frontend-builder /app/voc_frontend/dist ./voc_builder/notepad/dist
  15 |     COPY voc_builder ./voc_builder
--------------------
ERROR: failed to solve: process "/bin/sh -c poetry config virtualenvs.create false && poetry install --no-interaction --no-ansi" did not complete successfully: exit code: 1
```